### PR TITLE
fix bugs in digit codes

### DIFF
--- a/digit/uda_digit.py
+++ b/digit/uda_digit.py
@@ -211,6 +211,10 @@ def train_source(args):
                 best_netF = netF.state_dict()
                 best_netB = netB.state_dict()
                 best_netC = netC.state_dict()
+            
+            netF.train()
+            netB.train()
+            netC.train()
 
     torch.save(best_netF, osp.join(args.output_dir, "source_F.pt"))
     torch.save(best_netB, osp.join(args.output_dir, "source_B.pt"))
@@ -303,7 +307,7 @@ def train_target(args):
 
         if iter_num % interval_iter == 0 and args.cls_par > 0:
             netF.eval()
-            netF.eval()
+            netB.eval()
             mem_label = obtain_label(dset_loaders['target_te'], netF, netB, netC, args)
             mem_label = torch.from_numpy(mem_label).cuda()
             netF.train()
@@ -344,6 +348,8 @@ def train_target(args):
             args.out_file.write(log_str + '\n')
             args.out_file.flush()
             print(log_str+'\n')
+            netF.train()
+            netB.train()
 
     if args.issave:
         torch.save(netF.state_dict(), osp.join(args.output_dir, "target_F_" + args.savename + ".pt"))


### PR DESCRIPTION
Hello, your work is excellent. I'm very interested in your work, so I ran your code and reproduced most of the experiment results.
In the process of reproduction, I found three problems in the digital code.
1. Before calling the 'obtain_label()' function, ”netB.eval()" is mistakenly written as "netF.eval()", resulting in the BN layer of bottleneck module mistakenly stays in the .train() state.
2. In the "train_source()" function, you forgot to add "netF.train()", "netB.train()" and "netC.train()" in the end of the model validation process, so the mean and variance of the BN layers can not be updated  after the first finished the first model validation.
3. The "train_target()" function has the same problem as above. So Line of "netF.train()" and "netB.train()" should be added.

After fixing these bugs in the digit experiment code, the experiment results will be changed to some extent, especially the results of SHOT-IM method. The training process of SHOT-IM method will become stable and the score improvement is very obvious. The scores of SHOT-IM in my reproduction results are as follows.

SHOT-IM   S->M: 99.0±0.0; U->M: 98.3±0.5; M->U: 98.1±0.1; Avg.: 98.5.       