### PR TITLE
reduce random factors for reproducibility

### DIFF
--- a/digit/uda_digit.py
+++ b/digit/uda_digit.py
@@ -438,7 +438,8 @@ if __name__ == "__main__":
     torch.cuda.manual_seed(SEED)
     np.random.seed(SEED)
     random.seed(SEED)
-    # torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
 
     args.output_dir = osp.join(args.output, 'seed' + str(args.seed), args.dset)
     if not osp.exists(args.output_dir):


### PR DESCRIPTION
Hello, your work is really excellent. I'm very interested in your work ! So I ran your code and reproduced most of the experiment results.

In the process of reproducing the experiments, I found that I would get different scores by running the same script many times. So I believe we should add more restrictions in the code to reduce randomness and make the recurring results more certain. In this pull request, **I add some restrictions to the digit code**, including “torch.backends.cudnn.deterministic = True” and "torch.backends.cudnn.benchmark = False". I think such restrictions are necessary in your experiments.

The code in the object folder also has the same situation. If you agree with my thought, you can modify the object code, too.